### PR TITLE
Phpmyadmin

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,6 +18,8 @@ Vagrant.configure(2) do |config|
     gem install --no-ri --no-rdoc bundler
     puppet module install puppetlabs-apache
     puppet module install Slashbunny-phpfpm
+    puppet module install puppetlabs/vcsrepo
+    puppet module install velaluqa/phpmyadmin
 
     puppet resource package centos-release-scl-rh ensure=installed
     puppet apply /vagrant/site.pp
@@ -28,6 +30,7 @@ Vagrant.configure(2) do |config|
     ln -s /opt/rh/httpd24/root/etc/httpd /home/vagrant/etc-httpd
     ln -s /opt/rh/httpd24/root/var/www /root/var-www
     ln -s /opt/rh/httpd24/root/var/www /home/vagrant/var-www
+    cp /vagrant/files/config.inc.php /vagrant/phpmyadmin/config.inc.php
   SHELL2
 
   # Uncomment to for manifest development via Vim

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,10 +30,8 @@ Vagrant.configure(2) do |config|
     ln -s /opt/rh/httpd24/root/etc/httpd /home/vagrant/etc-httpd
     ln -s /opt/rh/httpd24/root/var/www /root/var-www
     ln -s /opt/rh/httpd24/root/var/www /home/vagrant/var-www
-    cp /vagrant/files/config.inc.php /vagrant/phpmyadmin/config.inc.php
+    cp /vagrant/files/config.inc.php /vagrant/website/phpmyadmin/config.inc.php
   SHELL2
-
-  config.vm.synced_folder "website/phpmyadmin", "/opt/rh/httpd24/root/var/www/main-site/phpmyadmin", create: true
 
   # Uncomment to for manifest development via Vim
   #config.vm.provision "shell", path: 'vim-setup.sh'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,6 +33,8 @@ Vagrant.configure(2) do |config|
     cp /vagrant/files/config.inc.php /vagrant/phpmyadmin/config.inc.php
   SHELL2
 
+  config.vm.synced_folder "website/phpmyadmin", "/opt/rh/httpd24/root/var/www/main-site/phpmyadmin", create: true
+
   # Uncomment to for manifest development via Vim
   #config.vm.provision "shell", path: 'vim-setup.sh'
 

--- a/files/config.inc.php
+++ b/files/config.inc.php
@@ -1,0 +1,8 @@
+<?php
+  $cfg['blowfish_secret'] = 'ba17c1ec07d65003';
+
+  $i=0;
+
+  $cfg['CheckConfigurationPermissions'] = false;
+
+?>

--- a/phpmyadmin/config.inc.php
+++ b/phpmyadmin/config.inc.php
@@ -1,8 +1,0 @@
-<?php
-  $cfg['blowfish_secret'] = 'ba17c1ec07d65003';
-
-  $i=0;
-
-  $cfg['CheckConfigurationPermissions'] = false;
-
-?>

--- a/phpmyadmin/config.inc.php
+++ b/phpmyadmin/config.inc.php
@@ -1,0 +1,8 @@
+<?php
+  $cfg['blowfish_secret'] = 'ba17c1ec07d65003';
+
+  $i=0;
+
+  $cfg['CheckConfigurationPermissions'] = false;
+
+?>

--- a/site.pp
+++ b/site.pp
@@ -106,6 +106,17 @@ class {'phpfpm':
   restart_command => 'systemctl reload rh-php56-php-fpm',
 }
 
+class { 'phpmyadmin':
+  path    => "${scl_httpd}/var/www/main-site/phpmyadmin",
+  user    => $website_owner,
+  require => Class['apache'],
+}
+
+file { "${scl_httpd}/var/www/main-site/phpmyadmin":
+  ensure => directory,
+  before => File['phpmyadmin'],
+}
+
 file { "${scl_httpd}/var/www/main-site":
   ensure  => link,
   target  => '/vagrant/website',

--- a/site.pp
+++ b/site.pp
@@ -112,11 +112,6 @@ class { 'phpmyadmin':
   require => Class['apache'],
 }
 
-file { "${scl_httpd}/var/www/main-site/phpmyadmin":
-  ensure => directory,
-  before => File['phpmyadmin'],
-}
-
 file { "${scl_httpd}/var/www/main-site":
   ensure  => link,
   target  => '/vagrant/website',


### PR DESCRIPTION
Added the copy command in the vagrantFile instead of site.pp to avoid a duplication of resources error.

The puppetlabs/vcsrepo is a dependency of of velaluqa/phpmyadmin, which is a module that installs phpmyadmin via downloading and compiling the source code directly from GitHub.

Since a Linux guest cannot properly detect permissions on a Windows filesystem I added the necessary config line to diable checking or else the login page cannot be reached
