### PR TITLE
Enhancements to apache and php-fpm

### DIFF
--- a/php-fpm.conf
+++ b/php-fpm.conf
@@ -23,12 +23,35 @@ AddType text/html .php
 #
 DirectoryIndex index.php
 
-LoadModule proxy_fcgi_module modules/mod_proxy_fcgi.so
+# mod_php options
+<IfModule  mod_php5.c>
+    #
+    # Cause the PHP interpreter to handle files with a .php extension.
+    #
+    <FilesMatch \.php$>
+        SetHandler application/x-httpd-php
+    </FilesMatch>
 
+    #
+    # Uncomment the following lines to allow PHP to pretty-print .phps
+    # files as PHP source code:
+    #
+    #<FilesMatch \.phps$>
+    #    SetHandler application/x-httpd-php-source
+    #</FilesMatch>
+
+    #
+    # Apache specific PHP configuration options
+    # those can be override in each configured vhost
+    #
+    php_value session.save_handler "files"
+    php_value session.save_path    "/var/opt/rh/rh-php56/lib/php/session"
+    php_value soap.wsdl_cache_dir  "/var/opt/rh/rh-php56/lib/php/wsdlcache"
+</IfModule>
 <IfModule !mod_php5.c>
     <FilesMatch \.php$>
-        SetHandler "proxy:fcgi://127.0.0.1:9000"
+        SetHandler "proxy:unix:/opt/rh/rh-php56/root/var/run/php-fpm/php-fpm.sock|fcgi://127.0.0.1:9000"
     </FilesMatch>
-    <Proxy "fcgi://127.0.0.1:9000" enablereuse=on max=10>
+    <Proxy "fcgi://127.0.0.1:9000">
     </Proxy>
 </IfModule>

--- a/site.pp
+++ b/site.pp
@@ -1,7 +1,13 @@
+$apache_user   = 'vagrant'
 $website_owner = 'vagrant'
+$website_group = 'vagrant'
+$log_formats      = {
+  'combined' => '%a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"',
+}
 
 exec { 'create localhost cert':
   # lint:ignore:80chars
+  # lint:ignore:140chars
   command   => "/bin/openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 -sha256 -subj '/CN=domain.com/O=My Company Name LTD./C=US' -keyout /etc/pki/tls/private/localhost.key -out /etc/pki/tls/certs/localhost.crt",
   # lint:endignore
   creates   => '/etc/pki/tls/certs/localhost.crt',
@@ -9,9 +15,11 @@ exec { 'create localhost cert':
   before    => Class['apache'],
 }
 
-user { $website_owner:
-  ensure => present,
-  before => Class['apache'],
+if ($apache_user != $website_owner) {
+  user { $website_owner:
+    ensure => present,
+    before => Class['apache'],
+  }
 }
 
 $scl_httpd = '/opt/rh/httpd24/root'
@@ -21,15 +29,17 @@ class { 'apache':
   apache_version        => '2.4',
   conf_dir              => "${scl_httpd}/etc/httpd/conf",
   confd_dir             => "${scl_httpd}/etc/httpd/conf.d",
+  default_charset       => 'UTF-8',
   default_mods          => false,
   default_ssl_vhost     => false,
   default_vhost         => false,
   dev_packages          => 'httpd24-httpd-devel',
   docroot               => "${scl_httpd}/var/www/html",
   httpd_dir             => "${scl_httpd}/etc/httpd",
+  log_formats           => $log_formats,
   logroot               => '/var/log/httpd24',
   mod_dir               => "${scl_httpd}/etc/httpd/conf.modules.d",
-  mpm_module            => 'worker',
+  mpm_module            => 'event',
   pidfile               => '/opt/rh/httpd24/root/var/run/httpd/httpd.pid',
   ports_file            => "${scl_httpd}/etc/httpd/conf/ports.conf",
   purge_configs         => true,
@@ -37,7 +47,9 @@ class { 'apache':
   servername            => 'demobox.example.com',
   server_root           => "${scl_httpd}/etc/httpd",
   service_name          => 'httpd24-httpd',
+  ssl_file              => "${scl_httpd}/etc/httpd/conf.modules.d/ssl.conf",
   trace_enable          => false,
+  user                  => $apache_user,
   vhost_dir             => "${scl_httpd}/etc/httpd/conf.d",
   vhost_include_pattern => '*.conf',
 }
@@ -48,18 +60,6 @@ apache::custom_config { 'php-fpm':
   source         => '/vagrant/php-fpm.conf',
   verify_command => '/bin/scl enable httpd24 "apachectl -t"',
   notify         => Service['httpd'],
-}
-
-if ($::apache::mod_dir != $::apache::config_dir) {
-  apache::custom_config { 'mod_ssl_fix':
-    name           => 'ssl',
-    confdir        => "${scl_httpd}/etc/httpd/conf.d",
-    priority       => false,
-    content        => "# This file has moved to ${::apache::mod_dir}",
-    verify_command => '/bin/scl enable httpd24 "apachectl -t"',
-    require        => Class['apache::mod::ssl'],
-    notify         => Service['httpd'],
-  }
 }
 
 apache::vhost { 'main-site-nonssl':
@@ -84,11 +84,32 @@ apache::vhost { 'main-site-ssl':
 }
 
 class { 'apache::dev': }
+::apache::mod { 'access_compat': }
+class { 'apache::mod::alias': }
+class { 'apache::mod::auth_basic': }
+class { 'apache::mod::authn_core': }
+class { 'apache::mod::authn_file': }
+class { 'apache::mod::authz_user': }
+::apache::mod { 'authz_groupfile': }
 class { 'apache::mod::dir': }
+class { 'apache::mod::info':
+  allow_from => ['127.0.0.1','::1'],
+  info_path  => '/server-info',
+}
 class { 'apache::mod::proxy': }
+class { 'apache::mod::proxy_balancer': }
+class { 'apache::mod::proxy_fcgi': }
+class { 'apache::mod::remoteip':
+  proxy_ips => [ '127.0.0.1' ],
+}
+class { 'apache::mod::rewrite': }
 class { 'apache::mod::setenvif': }
 class { 'apache::mod::ssl':
   package_name => 'httpd24-mod_ssl',
+}
+class { 'apache::mod::status':
+  allow_from  => ['127.0.0.1','::1'],
+  status_path => '/server-status',
 }
 
 file { '/var/log/php-fpm':
@@ -97,13 +118,65 @@ file { '/var/log/php-fpm':
   before => Class['phpfpm'],
 }
 
+$phpfpm_sock_dirs = [
+  '/opt/rh/rh-php56/root/var/run',
+  '/opt/rh/rh-php56/root/var/run/php-fpm',
+]
+
+file { $phpfpm_sock_dirs:
+  ensure => directory,
+  owner  => $website_owner,
+  group  => $website_group,
+  mode   => '0755',
+  before => Class['phpfpm'],
+}
+
+file { '/var/opt/rh/rh-php56/lib/php/session':
+  ensure  => directory,
+  owner   => $website_owner,
+  group   => $website_group,
+  require => Class['phpfpm'],
+}
+
 class {'phpfpm':
   package_name    => 'rh-php56-php-fpm',
   service_name    => 'rh-php56-php-fpm',
   config_dir      => '/etc/opt/rh/rh-php56',
+  error_log       => '/var/opt/rh/rh-php56/log/php-fpm/error.log',
   pool_dir        => '/etc/opt/rh/rh-php56/php-fpm.d',
+  poold_purge     => true,
   pid_file        => '/var/opt/rh/rh-php56/run/php-fpm/php-fpm.pid',
   restart_command => 'systemctl reload rh-php56-php-fpm',
+}
+
+phpfpm::pool { 'www':
+  user                   => $website_owner,
+  group                  => $website_group,
+  # lint:ignore:80chars
+  listen                 => '/opt/rh/rh-php56/root/var/run/php-fpm/php-fpm.sock',
+  # lint:endignore
+  listen_allowed_clients => '127.0.0.1',
+  listen_owner           => $website_owner,
+  listen_group           => $website_group,
+  listen_mode            => '0660',
+  pm_max_children        => 250,
+  pm_start_servers       => 50,
+  pm_min_spare_servers   => 25,
+  pm_max_spare_servers   => 50,
+  pool_dir               => '/etc/opt/rh/rh-php56/php-fpm.d',
+  slowlog                => '/var/opt/rh/rh-php56/log/php-fpm/www-slow.log',
+  service_name           => 'rh-php56-php-fpm',
+  php_admin_value        => {
+    'error_log' => '/var/opt/rh/rh-php56/log/php-fpm/www-error.log',
+  },
+  php_admin_flag         => {
+    'log_errors' => 'on',
+  },
+  php_value              => {
+    'session.save_handler' => 'files',
+    'session.save_path'    => '/var/opt/rh/rh-php56/lib/php/session',
+    'soap.wsdl_cache_dir'  => '/var/opt/rh/rh-php56/lib/php/wsdlcache',
+  },
 }
 
 file { "${scl_httpd}/var/www/main-site":
@@ -121,19 +194,19 @@ file { "${scl_httpd}/var/www/main-site/index.php":
 }
 
 $php_packages = [
-  rh-php56-php-bcmath,
-  rh-php56-php-cli,
-  rh-php56-php-common,
-  rh-php56-php-devel,
-  rh-php56-php-gd,
-  rh-php56-php-mbstring,
-  rh-php56-php-mysqlnd,
-  rh-php56-php-pdo,
-  rh-php56-php-pear,
-  rh-php56-php-pecl-jsonc,
-  rh-php56-php-pecl-jsonc-devel,
-  rh-php56-php-process,
-  rh-php56-php-xml,
+  'rh-php56-php-bcmath',
+  'rh-php56-php-cli',
+  'rh-php56-php-common',
+  'rh-php56-php-devel',
+  'rh-php56-php-gd',
+  'rh-php56-php-mbstring',
+  'rh-php56-php-mysqlnd',
+  'rh-php56-php-pdo',
+  'rh-php56-php-pear',
+  'rh-php56-php-pecl-jsonc',
+  'rh-php56-php-pecl-jsonc-devel',
+  'rh-php56-php-process',
+  'rh-php56-php-xml',
 ]
 
 package { $php_packages:


### PR DESCRIPTION
Please see the commit below for the following enhancements to the LAMP stack:

- Moved mod_proxy_fcgi to be managed by puppet.
- Configured php-fpm to use unix socket, since apache and php-fpm are running on the same box.
- Added combined log format.
- Changed MPM module to event
- Moved custom config `mod_ssl_fix` to a new apache class parameter `ssl_file`.
- Added other generally used used apache modules.
- Added directories and pool config to support the use of php-fpm socket.
- Fixed syntax found by puppet-lint.

Please let me know your thoughts and if you have and questions or recommendations!

Respectfully,
Jake